### PR TITLE
Pin CI pipelines to ubuntu-24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     name: "Ruby ${{ matrix.ruby }}"
     env:
       RUBY_YJIT_ENABLE: "1"


### PR DESCRIPTION
Squishes warning output in every CI run